### PR TITLE
📢 (fix) update custom glab registry

### DIFF
--- a/app/utils/dockerapi.py
+++ b/app/utils/dockerapi.py
@@ -70,7 +70,7 @@ def get_digitalocean_auth(image: Image):
 def get_gitlab_auth(image: Image):
     """get_gitlab_auth"""
     auth_service = "container_registry"
-    auth_url = "https://gitlab.com/jwt/auth"
+    auth_url = config.get_urunner_conf_container_registry_to_watch() or "https://gitlab.com/jwt/auth"
     do_token = config.get_urunner_secr_gitlab_token()
     do_token = b64encode(f"{do_token}:{do_token}".encode("ascii")).decode("ascii")
     auth_header = f"Basic {do_token}"


### PR DESCRIPTION
## Bugs fixed
- Fixed a bug where, when using a private gitlab registry, `urunner` would still use `gitlab.com`